### PR TITLE
Fix proxy support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require "rake/testtask"
 require "rake/clean"
 require "rubygems"
 
-require "lib/simple_http"
+load "lib/simplehttp.rb"
 
 # Specifies the default task to execute. This is often the "test" task
 # and we'll change things around as soon as we have some tests.

--- a/lib/simplehttp.rb
+++ b/lib/simplehttp.rb
@@ -276,7 +276,7 @@ class SimpleHttp
       if !port && !user && !pwd
         proxy = URI.parse(proxy)
       else 
-        @proxy_host= host
+        @proxy_host= proxy
         @proxy_port= port
         @proxy_user= user
         @proxy_pwd = pwd

--- a/test/http_test.rb
+++ b/test/http_test.rb
@@ -1,4 +1,4 @@
-require 'simple_http.rb'
+require 'simplehttp.rb'
 require 'http_test_server.rb'
 
 require 'test/unit'
@@ -11,16 +11,25 @@ require 'base64'
 class SimpleHttpTest < Test::Unit::TestCase
   def initialize *args
     super *args
+  end
+
+  def setup
     # create webbrick server in a separate thread
-    Thread.new {
-      TestServer.new.start
+    @server = TestServer.new
+    t = Thread.new {
+      @server.start
     }
+    while @server.status != :Running
+      Thread.pass
+      unless t.alive?
+        t.join
+        raise
+      end
+    end
   end
 
   def teardown
-    #@t.shutdown # webrick blocks in a weird way, can't
-    #commnicate with it in a different thread. this, of
-    #course, is really ugly.
+    @server.shutdown
   end
 
   # Tests of SimpleHttp class method behaviour.

--- a/test/http_test.rb
+++ b/test/http_test.rb
@@ -4,11 +4,14 @@ require 'http_test_server.rb'
 require 'test/unit'
 require 'uri'
 require 'base64'
+require 'webrick/httpproxy'
 
 # These tests communicate with a corresponding http server (TestServer), which is
 # implemented in `http_test_server.rb`
 
 class SimpleHttpTest < Test::Unit::TestCase
+  ProxyPort = 12346
+
   def initialize *args
     super *args
   end
@@ -16,20 +19,12 @@ class SimpleHttpTest < Test::Unit::TestCase
   def setup
     # create webbrick server in a separate thread
     @server = TestServer.new
-    t = Thread.new {
-      @server.start
-    }
-    while @server.status != :Running
-      Thread.pass
-      unless t.alive?
-        t.join
-        raise
-      end
-    end
+    start_server_thread(@server)
   end
 
   def teardown
     @server.shutdown
+    teardown_proxyserver if @proxyserver
   end
 
   # Tests of SimpleHttp class method behaviour.
@@ -217,7 +212,41 @@ class SimpleHttpTest < Test::Unit::TestCase
     assert_equal(ret, TestServer::SUCCESS_TEXT_0, "redirect test 2");
   end
 
+  def test_proxy_server
+    setup_proxyserver
+    http = SimpleHttp.new "http://test:pwd@127.0.0.1:12345/basic_auth"
+    http.set_proxy('127.0.0.1', ProxyPort)
+    ret = http.get
+    assert_equal(TestServer::SUCCESS_TEXT_1, ret, "basic auth get class 1 test failed.");
+  end
 
+  def setup_proxyserver
+    @proxyserver = WEBrick::HTTPProxyServer.new(
+      :BindAddress => "127.0.0.1",
+      :Port => ProxyPort,
+      :AccessLog => []
+    )
+    start_server_thread(@proxyserver)
+  end
+
+  def teardown_proxyserver
+    @proxyserver.shutdown
+  end
+
+  def start_server_thread(server)
+    t = Thread.new {
+      Thread.current.abort_on_exception = true
+      server.start
+    }
+    while server.status != :Running
+      Thread.pass
+      unless t.alive?
+        t.join
+        raise
+      end
+    end
+    t
+  end
 
 end
 

--- a/test/http_test_server.rb
+++ b/test/http_test_server.rb
@@ -32,6 +32,10 @@ class TestServer
     @server.shutdown
   end
 
+  def status
+    @server.status
+  end
+
   def dbg str 
     puts "!!!!!!!!! #{str}"
   end


### PR DESCRIPTION
I found a typo in proxy support of simplehttp while evaluating Ruby HTTP clients at https://github.com/nahi/odrk-http-client
Sorry but I'm not an user of simplehttp so feel free to ignore this request.
